### PR TITLE
NiHSA and GloFAS reanalysis

### DIFF
--- a/exploration/glofas.md
+++ b/exploration/glofas.md
@@ -313,3 +313,7 @@ rea[(rea["time"] >= "2022-07-01") & (rea["time"] < "2022-11-01")].plot(
 ```python
 rea.loc[rea["dis24"].idxmax()]
 ```
+
+```python
+
+```

--- a/exploration/glofas_new_reanalysis.md
+++ b/exploration/glofas_new_reanalysis.md
@@ -1,0 +1,60 @@
+---
+jupyter:
+  jupytext:
+    formats: ipynb,md
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.16.1
+  kernelspec:
+    display_name: ds-aa-nga-flooding
+    language: python
+    name: ds-aa-nga-flooding
+---
+
+# GloFAS new reanalysis
+
+```python
+%load_ext jupyter_black
+%load_ext autoreload
+%autoreload 2
+```
+
+```python
+import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
+import pandas as pd
+import xarray as xr
+
+from src.datasources import nihsa, glofas
+from src.utils import blob
+```
+
+```python
+station_name = "wuroboki"
+```
+
+```python
+glofas.download_glofas_reanalysis_to_blob(station_name=station_name)
+```
+
+```python
+glofas.process_glofas_reanalysis(station_name=station_name)
+```
+
+```python
+df_ra = glofas.load_glofas_reanalysis(station_name=station_name)
+```
+
+```python
+df_ra
+```
+
+```python
+df_nh = nihsa.load_wuroboki()
+```
+
+```python
+df_nh
+```

--- a/exploration/glofas_new_reanalysis.md
+++ b/exploration/glofas_new_reanalysis.md
@@ -58,3 +58,142 @@ df_nh = nihsa.load_wuroboki()
 ```python
 df_nh
 ```
+
+```python
+df_compare = df_ra.merge(df_nh, how="left")
+```
+
+```python
+df_compare
+```
+
+```python
+months = range(7, 11)
+df_plot = df_compare[
+    (df_compare["time"].dt.month.isin(months))
+    # & (df_compare["time"].dt.year.isin(nihsa.WUROBOKI_COMPLETE_YEARS))
+]
+
+dis_max = df_plot["dis24"].max()
+level_max = df_plot["level"].max()
+
+n_years = df_plot["time"].dt.year.nunique()
+
+ncols = 3
+nrows = round(n_years / ncols) + 1
+
+fig, axes = plt.subplots(
+    nrows=nrows, ncols=ncols, figsize=(ncols * 5, nrows * 3)
+)
+axes = axes.flatten()
+
+for j, year in enumerate(df_plot["time"].dt.year.unique()):
+    dff = df_plot[df_plot["time"].dt.year == year]
+    ax = axes[j]
+    ax2 = ax.twinx()
+
+    ax.plot(
+        dff["time"],
+        dff["level"],
+        color="dodgerblue",
+        label="NiHSA\n(mm, left axis)",
+    )
+    ax.set_ylim(bottom=0, top=level_max * 1.1)
+
+    ax2.plot(
+        dff["time"],
+        dff["dis24"],
+        color="darkorange",
+        label="GloFAS\n(m$^{3}$/s, right axis)",
+    )
+    ax2.set_ylim(bottom=0, top=dis_max * 1.1)
+
+    ax.xaxis.set_major_locator(mdates.MonthLocator())
+    ax.xaxis.set_major_formatter(mdates.DateFormatter("%b"))
+    ax.set_title(year)
+
+    if j == 0:
+        ax.legend(loc="upper left")
+        ax2.legend(loc="upper right")
+
+
+fig.suptitle(
+    f"Comparison of NiHSA and GloFAS reanalysis for {station_name.capitalize()}",
+    fontsize=16,
+    y=1,
+)
+
+plt.tight_layout()
+
+plt.savefig(
+    "temp/wuroboki_nihsa_glofas_comparison.png", dpi=200, bbox_inches="tight"
+)
+```
+
+```python
+df_compare.corr()
+```
+
+```python
+df_peaks = df_compare.groupby(df_compare["time"].dt.year.rename("year")).agg(
+    dis24_max=("dis24", "max"),
+    dis24_max_date=("dis24", lambda x: df_compare.loc[x.idxmax(), "time"]),
+    level_max=("level", "max"),
+    level_max_date=(
+        "level",
+        lambda x: (
+            df_compare.loc[x.idxmax(), "time"] if x.notna().any() else pd.NaT
+        ),
+    ),
+)
+```
+
+```python
+df_peaks.corr()
+```
+
+```python
+df_peaks.loc[nihsa.WUROBOKI_COMPLETE_YEARS].corr()
+```
+
+```python
+df_plot["dis24_max"].quantile(1 - 1 / rp)
+```
+
+```python
+df_peaks.loc[2000:]
+```
+
+```python
+
+```
+
+```python
+# df_plot = df_peaks.loc[nihsa.WUROBOKI_COMPLETE_YEARS].copy()
+df_plot = df_peaks.loc[2013:]
+# df_plot = df_peaks.copy()
+
+rp = 3
+
+fig, ax = plt.subplots(dpi=200, figsize=(7, 7))
+
+dis24_thresh = df_plot["dis24_max"].quantile(1 - 1 / rp)
+level_thresh = df_plot["level_max"].quantile(1 - 1 / rp)
+
+for year, row in df_plot.iterrows():
+    ax.annotate(
+        year,
+        (row["dis24_max"], row["level_max"]),
+        ha="center",
+        va="center",
+        fontsize=8,
+    )
+
+ax.axvline(dis24_thresh)
+ax.axhline(level_thresh)
+
+ax.set_ylim(bottom=0, top=df_plot["level_max"].max() * 1.1)
+ax.set_xlim(left=0, right=df_plot["dis24_max"].max() * 1.1)
+
+plt.tight_layout()
+```

--- a/exploration/wuroboki.md
+++ b/exploration/wuroboki.md
@@ -13,7 +13,7 @@ jupyter:
     name: ds-aa-nga-flooding
 ---
 
-# Wuroboki
+# Wuroboki - NiHSA
 
 ```python
 %load_ext jupyter_black
@@ -22,22 +22,76 @@ jupyter:
 ```
 
 ```python
-from src.datasources import nihsa
+import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
+import pandas as pd
+import xarray as xr
+
+from src.datasources import nihsa, glofas
 ```
 
 ```python
-df = nihsa.load_wuroboki()
-df
+df_nihsa = nihsa.load_wuroboki()
+df_nihsa
 ```
 
 ```python
-df.sort_values("level")
+df_nihsa.sort_values("level")
 ```
 
 ```python
 df.groupby(df["time"].dt.year)["level"].max().reset_index().sort_values(
     "level"
 )
+```
+
+```python
+df_plot = df[df["time"].dt.year >= 2000].copy()
+df_plot["year"] = df_plot["time"].dt.year
+```
+
+```python
+ymax = df_plot["level"].max()
+
+fig, axes = plt.subplots(
+    nrows=8, ncols=3, figsize=(15, 25)
+)  # Adjust rows to fit all 25 years
+axes = axes.flatten()  # Flatten axes array for easy indexing
+
+# Loop through each year and plot in corresponding subplot
+for i, year in enumerate(df_plot["year"].unique()):
+    ax = axes[i]
+    year_data = df_plot[df_plot["year"] == year]
+
+    # Plot the data
+    ax.plot(year_data["time"], year_data["level"])  # Adjust 'level' as needed
+    ax.set_title(f"Year {year}")
+    ax.set_xlabel("Time")
+    ax.set_ylabel("Level")
+
+    # Set the y-axis to range from 0 to the maximum value
+    ax.set_ylim(0, ymax)
+
+    # Set x-axis to span from Jan 1 to Dec 31 for each year
+    start_date = pd.Timestamp(f"{year}-01-01")
+    end_date = pd.Timestamp(f"{year}-12-31")
+    ax.set_xlim(start_date, end_date)
+
+    # Format x-axis to show months/days (e.g., Jan 01, Feb 01, etc.)
+    ax.xaxis.set_major_locator(
+        mdates.MonthLocator()
+    )  # Show major ticks for each month
+    ax.xaxis.set_major_formatter(
+        mdates.DateFormatter("%b-%d")
+    )  # Month and day format
+
+# Adjust layout and display
+plt.tight_layout()
+plt.show()
+```
+
+```python
+df[df["time"].dt.year == 2021].plot(x="time", y="level")
 ```
 
 ```python

--- a/exploration/wuroboki.md
+++ b/exploration/wuroboki.md
@@ -31,31 +31,53 @@ from src.datasources import nihsa, glofas
 ```
 
 ```python
-df_nihsa = nihsa.load_wuroboki()
-df_nihsa
+df_nh = nihsa.load_wuroboki()
+df_nh
 ```
 
 ```python
-df_nihsa.sort_values("level")
+df_nh.sort_values("level")
 ```
 
 ```python
-df.groupby(df["time"].dt.year)["level"].max().reset_index().sort_values(
+df_nh.groupby(df_nh["time"].dt.year)["level"].max().reset_index().sort_values(
     "level"
 )
 ```
 
 ```python
-df_plot = df[df["time"].dt.year >= 2000].copy()
+df_nh["level_change"] = df_nh["level"] - df_nh["level"].shift()
+```
+
+```python
+df_plot = df_nh[df_nh["time"].dt.year >= 1979].copy()
 df_plot["year"] = df_plot["time"].dt.year
 ```
 
 ```python
-ymax = df_plot["level"].max()
+n_years = df_plot["year"].nunique()
+```
+
+```python
+n_years
+```
+
+```python
+df_plot["level_change"].min()
+```
+
+```python
+plot_col = "level"
+
+ymax = df_plot[plot_col].max()
+ymin = min(0, df_plot[plot_col].min())
+
+ncols = 3
+nrows = round(n_years / ncols) + 1
 
 fig, axes = plt.subplots(
-    nrows=8, ncols=3, figsize=(15, 25)
-)  # Adjust rows to fit all 25 years
+    nrows=nrows, ncols=ncols, figsize=(ncols * 5, nrows * 3), dpi=200
+)
 axes = axes.flatten()  # Flatten axes array for easy indexing
 
 # Loop through each year and plot in corresponding subplot
@@ -64,13 +86,13 @@ for i, year in enumerate(df_plot["year"].unique()):
     year_data = df_plot[df_plot["year"] == year]
 
     # Plot the data
-    ax.plot(year_data["time"], year_data["level"])  # Adjust 'level' as needed
+    ax.plot(year_data["time"], year_data[plot_col])  # Adjust 'level' as needed
     ax.set_title(f"Year {year}")
     ax.set_xlabel("Time")
     ax.set_ylabel("Level")
 
     # Set the y-axis to range from 0 to the maximum value
-    ax.set_ylim(0, ymax)
+    ax.set_ylim(ymin, ymax)
 
     # Set x-axis to span from Jan 1 to Dec 31 for each year
     start_date = pd.Timestamp(f"{year}-01-01")
@@ -82,7 +104,7 @@ for i, year in enumerate(df_plot["year"].unique()):
         mdates.MonthLocator()
     )  # Show major ticks for each month
     ax.xaxis.set_major_formatter(
-        mdates.DateFormatter("%b-%d")
+        mdates.DateFormatter("%b")
     )  # Month and day format
 
 # Adjust layout and display
@@ -91,9 +113,13 @@ plt.show()
 ```
 
 ```python
-df[df["time"].dt.year == 2021].plot(x="time", y="level")
+df_nh
 ```
 
 ```python
-
+year = 2021
+months = range(7, 11)
+df_nh[
+    (df_nh["time"].dt.year == year) & (df_nh["time"].dt.month.isin(months))
+].plot(x="time", y="level_change")
 ```

--- a/exploration/wuroboki.md
+++ b/exploration/wuroboki.md
@@ -1,0 +1,45 @@
+---
+jupyter:
+  jupytext:
+    formats: ipynb,md
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.16.1
+  kernelspec:
+    display_name: ds-aa-nga-flooding
+    language: python
+    name: ds-aa-nga-flooding
+---
+
+# Wuroboki
+
+```python
+%load_ext jupyter_black
+%load_ext autoreload
+%autoreload 2
+```
+
+```python
+from src.datasources import nihsa
+```
+
+```python
+df = nihsa.load_wuroboki()
+df
+```
+
+```python
+df.sort_values("level")
+```
+
+```python
+df.groupby(df["time"].dt.year)["level"].max().reset_index().sort_values(
+    "level"
+)
+```
+
+```python
+
+```

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,6 +2,10 @@ CERF_YEARS = [2013, 2018, 2022]
 ADAMAWA = "NG002"
 WUROBOKI_LAT = 9.375
 WUROBOKI_LON = 12.78
+# new values for 2025 reanalysis
+WUROBOKI_LAT_NEW = 9.375
+WUROBOKI_LON_NEW = 12.775
+
 WUROBOKI_2YRPR = 2200
 WUROBOKI_3YRPR = 2669
 # this is a visual guess from the GloFAS plot

--- a/src/datasources/nihsa.py
+++ b/src/datasources/nihsa.py
@@ -1,0 +1,14 @@
+from src.utils import blob
+
+
+def load_wuroboki():
+    blob_name = f"{blob.PROJECT_PREFIX}/raw/AA-nigeria_data/NiHSA/wuroboki_water level.xls"  # noqa
+    df = blob.load_excel_from_blob(blob_name, skiprows=1, parse_dates=["Date"])
+    df = df.rename(
+        columns={
+            "Date": "time",
+            "Hauteur écoulement (cm REFERENTIEL HYDROM)": "level",
+        }
+    ).drop(columns=["Validity"])
+    df = df[(df["level"] >= 0) & (df["level"] < 999999)]
+    return df

--- a/src/datasources/nihsa.py
+++ b/src/datasources/nihsa.py
@@ -1,3 +1,5 @@
+import pandas as pd
+
 from src.utils import blob
 
 
@@ -11,4 +13,23 @@ def load_wuroboki():
         }
     ).drop(columns=["Validity"])
     df = df[(df["level"] >= 0) & (df["level"] < 999999)]
+    df["time"] = pd.to_datetime(df["time"].dt.date)
     return df
+
+
+WUROBOKI_COMPLETE_YEARS = [
+    1979,
+    1983,
+    1988,
+    1989,
+    1991,
+    1992,
+    1993,  # maybe
+    2006,
+    2012,  # maybe
+    2016,  # maybe
+    2018,  # maybe
+    2021,  # but remove June, I think
+    2023,
+    2024,  # but still weird
+]

--- a/src/utils/blob.py
+++ b/src/utils/blob.py
@@ -26,6 +26,13 @@ prod_container_client = ContainerClient.from_container_url(PROD_BLOB_AA_URL)
 dev_container_client = ContainerClient.from_container_url(DEV_BLOB_PROJ_URL)
 
 
+def load_excel_from_blob(
+    blob_name, prod_dev: Literal["prod", "dev"] = "dev", **kwargs
+):
+    blob_data = load_blob_data(blob_name, prod_dev=prod_dev)
+    return pd.read_excel(io.BytesIO(blob_data), **kwargs)
+
+
 def load_parquet_from_blob(
     blob_name, prod_dev: Literal["prod", "dev"] = "dev"
 ):

--- a/src/utils/blob.py
+++ b/src/utils/blob.py
@@ -111,3 +111,25 @@ def list_container_blobs(
             name_starts_with=name_starts_with
         )
     ]
+
+
+def upload_parquet_to_blob(
+    blob_name,
+    df,
+    prod_dev: Literal["prod", "dev"] = "dev",
+    **kwargs,
+):
+    upload_blob_data(
+        blob_name,
+        df.to_parquet(**kwargs, index=False),
+        prod_dev=prod_dev,
+    )
+
+
+def check_blob_exists(blob_name, prod_dev: Literal["prod", "dev"] = "dev"):
+    if prod_dev == "dev":
+        container_client = dev_container_client
+    else:
+        container_client = prod_container_client
+    blob_client = container_client.get_blob_client(blob_name)
+    return blob_client.exists()

--- a/src/utils/cds_utils.py
+++ b/src/utils/cds_utils.py
@@ -1,0 +1,27 @@
+import os
+from pathlib import Path
+from typing import Literal
+
+import cdsapi
+
+from src.utils import blob
+
+
+def download_raw_cds_api_to_blob(
+    dataset: str,
+    request: dict,
+    blob_name: str,
+    prod_dev: Literal["prod", "dev"] = "dev",
+    keep_local_copy: bool = True,
+):
+    local_filepath = "temp" / Path(blob_name)
+    if not local_filepath.parent.exists():
+        os.makedirs(local_filepath.parent)
+    c = cdsapi.Client()
+    response = c.retrieve(dataset, request)
+    response.download(local_filepath)
+    with open(local_filepath, "rb") as file:
+        blob.upload_blob_data(blob_name, file, prod_dev=prod_dev)
+    if not keep_local_copy:
+        os.remove(local_filepath)
+    return local_filepath if keep_local_copy else None


### PR DESCRIPTION
Does two basic things:

1. Downloads, processes, loads GloFAS reanalysis
   - I tried to make this generalizable, where you can add the coordinates of a station to `src.datasources.glofas.GF_STATIONS`, and go from there. Note that specifying the coordinates is helpful, because otherwise CDS returns a high-resolution raster, and we only really care about a single pixel. So the query to CDS puts the smallest increment possible between north and south, and east and west (`pitch` in `download_glofas_reanalysis_year_to_blob()`) so only a single pixel is returned.
   - I also included `src.utils.cds_utils`, which should work to download any CDS query to the blob. 
2. Loads NiHSA observed river level, and compares to GloFAS reanalysis
   - These notebooks can be largely ignored since they have since these have basically been replaced by more recent analysis. They were more just to take a quick look at the data.