### PR TITLE
default to prod when running from gha

### DIFF
--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -13,7 +13,7 @@ on:
         options:
           - dev
           - prod
-        default: prod
+        default: dev
 
   schedule:
     - cron: '0 20 * * *'
@@ -56,7 +56,7 @@ jobs:
         DSCI_AWS_EMAIL_ADDRESS: ${{ secrets.DSCI_AWS_EMAIL_ADDRESS}}
         DSCI_AWS_EMAIL_PORT: 465
         MONITORING_DATE: ${{ inputs.date || '' }}
-        STAGE: ${{ inputs.stage }}
+        STAGE: ${{ inputs.stage || 'prod'}}
 
       run: |
         python pipelines/check_forecasts.py


### PR DESCRIPTION
So that the emails actually send to the mailing list from the GitHub action