### PR TITLE
Add country-wide GloFAS reforecast download pipeline

### DIFF
--- a/databricks.yml
+++ b/databricks.yml
@@ -63,7 +63,7 @@ resources:
         - name: rainy_season_only
           default: "true"
         - name: cds_url
-          default: ""
+          default: "https://ewds.climate.copernicus.eu/api"
 
       job_clusters:
         - job_cluster_key: main

--- a/databricks.yml
+++ b/databricks.yml
@@ -62,16 +62,21 @@ resources:
           default: "4"
         - name: rainy_season_only
           default: "true"
+        - name: cds_url
+          default: ""
 
       job_clusters:
         - job_cluster_key: main
           new_cluster:
-            # Job Compute policy injects CDSAPI_KEY + DSCI_AZ_* from the dsci
-            # secret scope. CDSAPI_URL is not in that scope, so set it here.
+            # Job Compute policy injects CDSAPI_KEY + DSCI_AZ_* from dsci scope.
+            # Policy enforces CDSAPI_URL=https://cds.climate.copernicus.eu/api
+            # and num_workers=1; set both explicitly to satisfy validation.
+            # Note: the working station job used https://ewds.climate.copernicus.eu/api
+            # (hardcoded in the notebook). If this URL fails for GloFAS, the
+            # entrypoint can be updated to override via --cds-url.
             policy_id: "000C79D951EAF0D6"
             apply_policy_default_values: true
-            spark_env_vars:
-              CDSAPI_URL: "https://ewds.climate.copernicus.eu/api"
+            num_workers: 1
 
       tasks:
         - task_key: download
@@ -92,6 +97,8 @@ resources:
               - "{{job.parameters.max_leadtime_chunk}}"
               - "--rainy-season-only"
               - "{{job.parameters.rainy_season_only}}"
+              - "--cds-url"
+              - "{{job.parameters.cds_url}}"
 
 targets:
   dev:

--- a/databricks.yml
+++ b/databricks.yml
@@ -81,6 +81,19 @@ resources:
       tasks:
         - task_key: download
           job_cluster_key: main
+          libraries:
+            - pypi:
+                package: cdsapi
+            - pypi:
+                package: ocha-stratus
+            - pypi:
+                package: cfgrib
+            - pypi:
+                package: "eccodes==2.42.0"
+            - pypi:
+                package: python-dotenv
+            - pypi:
+                package: xarray
           spark_python_task:
             python_file: pipelines/download_glofas_reforecast_country.py
             source: GIT

--- a/databricks.yml
+++ b/databricks.yml
@@ -1,0 +1,104 @@
+# Databricks Asset Bundle — ds-aa-nga-flooding
+#
+# Currently defines one job: download_glofas_reforecast_country
+# (long-running one-shot download of the whole-Nigeria GloFAS reforecast).
+#
+# Common commands:
+#   databricks bundle validate -t dev -p DEFAULT
+#   databricks bundle deploy   -t dev -p DEFAULT
+#   databricks bundle run download_glofas_reforecast_country -t dev -p DEFAULT
+#
+# Override parameters at run time with --python-named-params:
+#   databricks bundle run download_glofas_reforecast_country -t dev -p DEFAULT \
+#       --python-named-params "product_type=control,start_year=2003,end_year=2024"
+
+bundle:
+  name: ds-aa-nga-flooding
+
+variables:
+  git_branch:
+    description: Repo branch the cluster pulls source from
+    default: main
+
+resources:
+  jobs:
+
+    download_glofas_reforecast_country:
+      name: Download GloFAS Reforecast (Country)
+      description: >
+        Download whole-Nigeria GloFAS reforecast from CDS API and save to blob.
+        Idempotent — skips files already present. Expected runtime: days.
+
+      permissions:
+        - group_name: dsci
+          level: CAN_MANAGE
+
+      git_source:
+        git_url: https://github.com/OCHA-DAP/ds-aa-nga-flooding.git
+        git_provider: gitHub
+        git_branch: ${var.git_branch}
+
+      # No schedule — trigger manually via UI or `databricks bundle run`.
+      # max_concurrent_runs: 1 prevents accidental double-kicks.
+      max_concurrent_runs: 1
+
+      # Full run:
+      #   databricks bundle run download_glofas_reforecast_country -t dev -p DEFAULT
+      #
+      # Smoke test (1 year, 1 leadtime chunk — ~30-60 min):
+      #   databricks bundle run download_glofas_reforecast_country -t dev -p DEFAULT \
+      #     --python-named-params "start_year=2003,end_year=2003,max_leadtime_days=4,max_leadtime_chunk=4"
+
+      parameters:
+        - name: product_type
+          default: "ensemble"
+        - name: start_year
+          default: "2003"
+        - name: end_year
+          default: "2024"
+        - name: max_leadtime_days
+          default: "16"
+        - name: max_leadtime_chunk
+          default: "4"
+        - name: rainy_season_only
+          default: "true"
+
+      job_clusters:
+        - job_cluster_key: main
+          new_cluster:
+            # Job Compute policy injects CDSAPI_KEY + DSCI_AZ_* from the dsci
+            # secret scope. CDSAPI_URL is not in that scope, so set it here.
+            policy_id: "000C79D951EAF0D6"
+            apply_policy_default_values: true
+            spark_env_vars:
+              CDSAPI_URL: "https://ewds.climate.copernicus.eu/api"
+
+      tasks:
+        - task_key: download
+          job_cluster_key: main
+          spark_python_task:
+            python_file: pipelines/download_glofas_reforecast_country.py
+            source: GIT
+            parameters:
+              - "--product-type"
+              - "{{job.parameters.product_type}}"
+              - "--start-year"
+              - "{{job.parameters.start_year}}"
+              - "--end-year"
+              - "{{job.parameters.end_year}}"
+              - "--max-leadtime-days"
+              - "{{job.parameters.max_leadtime_days}}"
+              - "--max-leadtime-chunk"
+              - "{{job.parameters.max_leadtime_chunk}}"
+              - "--rainy-season-only"
+              - "{{job.parameters.rainy_season_only}}"
+
+targets:
+  dev:
+    mode: development
+
+  prod:
+    mode: production
+    run_as:
+      # TODO: replace with a service principal once one is provisioned for this repo
+      user_name: adm.tdowning@global.un.org

--- a/pipelines/download_glofas_reforecast_country.py
+++ b/pipelines/download_glofas_reforecast_country.py
@@ -74,16 +74,25 @@ def main() -> None:
         type=lambda x: x.lower() == "true",
         default=True,
         metavar="true|false",
-        help="Restrict to rainy season months Jun–Dec (default: true)",
+        help="Restrict to rainy season months Jun-Dec (default: true)",
+    )
+    p.add_argument(
+        "--cds-url",
+        default=None,
+        help=(
+            "Override CDS API URL (e.g. https://ewds.climate.copernicus.eu/api"
+            "). Falls back to CDSAPI_URL env var or ~/.cdsapirc."
+        ),
     )
     args = p.parse_args()
 
     print(
         f"Starting country-wide GloFAS reforecast download: "
         f"product_type={args.product_type}, "
-        f"years={args.start_year}–{args.end_year}, "
+        f"years={args.start_year}-{args.end_year}, "
         f"max_leadtime_days={args.max_leadtime_days}, "
-        f"rainy_season_only={args.rainy_season_only}"
+        f"rainy_season_only={args.rainy_season_only}, "
+        f"cds_url={args.cds_url or '(from env)'}"
     )
 
     download_glofas_reforecast_country(
@@ -92,6 +101,7 @@ def main() -> None:
         max_leadtime_days=args.max_leadtime_days,
         max_leadtime_chunk=args.max_leadtime_chunk,
         rainy_season_only=args.rainy_season_only,
+        cds_url=args.cds_url or None,
     )
 
     print("Done.")

--- a/pipelines/download_glofas_reforecast_country.py
+++ b/pipelines/download_glofas_reforecast_country.py
@@ -1,0 +1,101 @@
+"""Databricks entrypoint: download whole-Nigeria GloFAS reforecast.
+
+Downloads the cems-glofas-reforecast dataset for the full Nigeria bounding
+box (NGA_BBOX) and saves one GRIB2 file per (year, leadtime chunk) to blob
+storage under:
+
+  ds-aa-nga-flooding/raw/glofas/reforecast_country/
+    glofas_raw_reforecast_country_{product_type}_{year}_lt{lt_start}-{lt_end}.grib
+
+The job is idempotent: it skips blobs that already exist.
+
+Usage (local):
+    python pipelines/download_glofas_reforecast_country.py
+
+Deploy and run on Databricks:
+    databricks bundle validate -t dev -p DEFAULT
+    databricks bundle deploy   -t dev -p DEFAULT
+    databricks bundle run download_glofas_reforecast_country -t dev -p DEFAULT
+
+Override parameters at run time (example — control product):
+    databricks bundle run download_glofas_reforecast_country \\
+        -t dev -p DEFAULT \\
+        --python-named-params "product_type=control"
+
+
+Size estimates (whole-country bbox, 0.05° grid, ~200×240 pixels):
+  Rainy season + 16-day leadtime  →  ~58 GB   (88 files: 22 yr × 4 chunks)
+  All months   + 46-day leadtime  →  ~430 GB  (528 files: 22 yr × 12 chunks)
+
+Runtime estimate: ~30–60 min per CDS request → 2–4 days for rainy/16d scope.
+"""
+
+import argparse
+
+from src.datasources.glofas import download_glofas_reforecast_country
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description="Download country-wide GloFAS reforecast to blob."
+    )
+    p.add_argument(
+        "--product-type",
+        default="ensemble",
+        choices=["ensemble", "control"],
+        help="CDS product type (default: ensemble)",
+    )
+    p.add_argument(
+        "--start-year",
+        type=int,
+        default=2003,
+        help="First historical year to download (default: 2003)",
+    )
+    p.add_argument(
+        "--end-year",
+        type=int,
+        default=2024,
+        help="Last historical year to download, inclusive (default: 2024)",
+    )
+    p.add_argument(
+        "--max-leadtime-days",
+        type=int,
+        default=16,
+        help="Maximum leadtime in days (default: 16; max available: 46)",
+    )
+    p.add_argument(
+        "--max-leadtime-chunk",
+        type=int,
+        default=4,
+        help="Leadtime days per CDS request (default: 4)",
+    )
+    p.add_argument(
+        "--rainy-season-only",
+        type=lambda x: x.lower() == "true",
+        default=True,
+        metavar="true|false",
+        help="Restrict to rainy season months Jun–Dec (default: true)",
+    )
+    args = p.parse_args()
+
+    print(
+        f"Starting country-wide GloFAS reforecast download: "
+        f"product_type={args.product_type}, "
+        f"years={args.start_year}–{args.end_year}, "
+        f"max_leadtime_days={args.max_leadtime_days}, "
+        f"rainy_season_only={args.rainy_season_only}"
+    )
+
+    download_glofas_reforecast_country(
+        product_type=args.product_type,
+        years=range(args.start_year, args.end_year + 1),
+        max_leadtime_days=args.max_leadtime_days,
+        max_leadtime_chunk=args.max_leadtime_chunk,
+        rainy_season_only=args.rainy_season_only,
+    )
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/datasources/glofas.py
+++ b/src/datasources/glofas.py
@@ -755,30 +755,31 @@ def download_glofas_reforecast_country(
                 year = futures[future]
                 try:
                     future.result()
-                    already = (
-                        (progress["product_type"] == product_type)
-                        & (progress["year"] == year)
-                        & (progress["lt_start"] == lt_start)
-                        & (progress["lt_end"] == lt_end)
-                    ).any()
-                    if not already:
-                        row = pd.DataFrame(
-                            [
-                                {
-                                    "product_type": product_type,
-                                    "year": year,
-                                    "lt_start": lt_start,
-                                    "lt_end": lt_end,
-                                    "downloaded_at": datetime.now(
-                                        timezone.utc
-                                    ).isoformat(),
-                                }
-                            ]
-                        )
-                        progress = pd.concat([progress, row], ignore_index=True)
-                        _save_progress(progress, prod_dev)
                 except Exception as e:
                     print(f"Failed year={year} lt={lt_start}-{lt_end}: {e}")
+                    continue
+                already = (
+                    (progress["product_type"] == product_type)
+                    & (progress["year"] == year)
+                    & (progress["lt_start"] == lt_start)
+                    & (progress["lt_end"] == lt_end)
+                ).any()
+                if not already:
+                    row = pd.DataFrame(
+                        [
+                            {
+                                "product_type": product_type,
+                                "year": year,
+                                "lt_start": lt_start,
+                                "lt_end": lt_end,
+                                "downloaded_at": datetime.now(
+                                    timezone.utc
+                                ).isoformat(),
+                            }
+                        ]
+                    )
+                    progress = pd.concat([progress, row], ignore_index=True)
+                    _save_progress(progress, prod_dev)
 
 
 def load_glofas_reforecast_country_pixel(

--- a/src/datasources/glofas.py
+++ b/src/datasources/glofas.py
@@ -598,6 +598,7 @@ def _download_country_chunk(
     product_type: Literal["ensemble", "control"],
     months: list,
     clobber: bool = False,
+    cds_url: str = None,
 ) -> None:
     product_type_str = (
         "ensemble_perturbed_reforecast"
@@ -627,6 +628,7 @@ def _download_country_chunk(
         request,
         blob_name,
         keep_local_copy=False,
+        cds_url=cds_url,
     )
 
 
@@ -638,6 +640,7 @@ def download_glofas_reforecast_country_year(
     rainy_season_only: bool = True,
     clobber: bool = False,
     max_workers: int = 4,
+    cds_url: str = None,
 ) -> None:
     """Download whole-Nigeria GloFAS reforecast for one year.
 
@@ -663,6 +666,7 @@ def download_glofas_reforecast_country_year(
                 product_type,
                 months,
                 clobber,
+                cds_url,
             ): lt_chunk
             for lt_chunk in leadtime_chunks
         }
@@ -686,7 +690,8 @@ def download_glofas_reforecast_country(
     max_leadtime_chunk: int = 4,
     rainy_season_only: bool = True,
     clobber: bool = False,
-    max_workers: int = 2,
+    max_workers: int = 4,
+    cds_url: str = None,
 ) -> None:
     """Download whole-Nigeria GloFAS reforecast for multiple years.
 
@@ -703,6 +708,7 @@ def download_glofas_reforecast_country(
             rainy_season_only=rainy_season_only,
             clobber=clobber,
             max_workers=max_workers,
+            cds_url=cds_url,
         )
 
 

--- a/src/datasources/glofas.py
+++ b/src/datasources/glofas.py
@@ -597,7 +597,12 @@ def _load_progress(prod_dev: Literal["prod", "dev"] = "dev") -> pd.DataFrame:
 def _save_progress(
     progress: pd.DataFrame, prod_dev: Literal["prod", "dev"] = "dev"
 ) -> None:
-    blob.upload_parquet_to_blob(PROGRESS_BLOB, progress, prod_dev=prod_dev)
+    import io
+
+    buf = io.BytesIO()
+    progress.to_parquet(buf, index=False)
+    buf.seek(0)
+    stratus.upload_blob_data(buf, PROGRESS_BLOB, stage=prod_dev)
 
 
 def get_blob_name_country(

--- a/src/datasources/glofas.py
+++ b/src/datasources/glofas.py
@@ -1,4 +1,5 @@
 import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Literal
 
@@ -31,6 +32,10 @@ GF_REFORECAST_RAW_DIR = (
 )
 GF_TEST_DIR = DATA_DIR / "public" / "raw" / "nga" / "glofas" / "test"
 GF_PROC_DIR = DATA_DIR / "public" / "processed" / "nga" / "glofas"
+
+# Nigeria bounding box for country-wide GloFAS downloads [N, W, S, E]
+# Covers the full country extent at 0.05° resolution (~200 × 240 grid cells).
+NGA_BBOX = [14.05, 2.65, 4.25, 14.75]
 
 GF_STATIONS = {
     "wuroboki": {"lon": 12.767, "lat": 9.383},
@@ -69,6 +74,10 @@ ALL_MONTHS = [
     "november",
     "december",
 ]
+
+# Numeric month formats for the new CDS API (used by country-level downloads)
+RAINY_SEASON_MONTHS_NUM = [f"{m:02}" for m in [6, 7, 8, 9, 10, 11, 12]]
+ALL_MONTHS_NUM = [f"{m:02}" for m in range(1, 13)]
 
 
 def get_coords(station_name):
@@ -568,6 +577,196 @@ def process_glofas_reforecast(
         f"glofas_reforecast_{station_name}_{product_type}.parquet"
     )
     stratus.upload_parquet_to_blob(df, out_blob)
+
+
+def get_blob_name_country(
+    year: int,
+    product_type: Literal["ensemble", "control"],
+    lt_start: int,
+    lt_end: int,
+) -> str:
+    return (
+        f"{src.constants.PROJECT_PREFIX}/raw/glofas/reforecast_country/"
+        f"glofas_raw_reforecast_country_{product_type}_{year}"
+        f"_lt{lt_start}-{lt_end}.grib"
+    )
+
+
+def _download_country_chunk(
+    year: int,
+    lt_chunk: list,
+    product_type: Literal["ensemble", "control"],
+    months: list,
+    clobber: bool = False,
+) -> None:
+    product_type_str = (
+        "ensemble_perturbed_reforecast"
+        if product_type == "ensemble"
+        else "control_reforecast"
+    )
+    lt_start, lt_end = lt_chunk[0], lt_chunk[-1]
+    blob_name = get_blob_name_country(year, product_type, lt_start, lt_end)
+    if not clobber and blob.check_blob_exists(blob_name):
+        print(f"skipping {blob_name}")
+        return
+    request = {
+        "system_version": ["version_4_0"],
+        "hydrological_model": ["lisflood"],
+        "product_type": [product_type_str],
+        "variable": ["river_discharge_in_the_last_24_hours"],
+        "hyear": [f"{year}"],
+        "hmonth": months,
+        "hday": [f"{x:02}" for x in range(1, 32)],
+        "leadtime_hour": [str(x) for x in lt_chunk],
+        "data_format": "grib2",
+        "download_format": "unarchived",
+        "area": NGA_BBOX,
+    }
+    cds_utils.download_raw_cds_api_to_blob(
+        "cems-glofas-reforecast",
+        request,
+        blob_name,
+        keep_local_copy=False,
+    )
+
+
+def download_glofas_reforecast_country_year(
+    year: int,
+    product_type: Literal["ensemble", "control"],
+    max_leadtime_days: int = 16,
+    max_leadtime_chunk: int = 4,
+    rainy_season_only: bool = True,
+    clobber: bool = False,
+    max_workers: int = 4,
+) -> None:
+    """Download whole-Nigeria GloFAS reforecast for one year.
+
+    Covers the full Nigeria bbox (~200 × 240 pixels at 0.05°). Splits requests
+    by leadtime chunk and runs up to max_workers chunks concurrently (CDS
+    allows ~2 concurrent requests per account). Files are NOT kept locally —
+    country-wide GRIBs are ~600 MB–1.5 GB each.
+
+    Use load_glofas_reforecast_country_pixel() to extract a pixel afterwards.
+    """
+    months = RAINY_SEASON_MONTHS_NUM if rainy_season_only else ALL_MONTHS_NUM
+    leadtimes = [x * 24 for x in range(1, max_leadtime_days + 1)]
+    leadtime_chunks = [
+        leadtimes[i : i + max_leadtime_chunk]
+        for i in range(0, len(leadtimes), max_leadtime_chunk)
+    ]
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = {
+            executor.submit(
+                _download_country_chunk,
+                year,
+                lt_chunk,
+                product_type,
+                months,
+                clobber,
+            ): lt_chunk
+            for lt_chunk in leadtime_chunks
+        }
+        for future in tqdm(
+            as_completed(futures),
+            total=len(futures),
+            desc=f"{year} lt chunks",
+        ):
+            lt_chunk = futures[future]
+            try:
+                future.result()
+            except Exception as e:
+                lt_start, lt_end = lt_chunk[0], lt_chunk[-1]
+                print(f"Failed year={year} lt={lt_start}-{lt_end}: {e}")
+
+
+def download_glofas_reforecast_country(
+    product_type: Literal["ensemble", "control"],
+    years: range = range(2003, 2025),
+    max_leadtime_days: int = 16,
+    max_leadtime_chunk: int = 4,
+    rainy_season_only: bool = True,
+    clobber: bool = False,
+    max_workers: int = 2,
+) -> None:
+    """Download whole-Nigeria GloFAS reforecast for multiple years.
+
+    Processes years in order (lowest first) so the blob store fills up
+    progressively and partial runs can resume without re-downloading.
+    Within each year, up to max_workers leadtime chunks run concurrently.
+    """
+    for year in tqdm(years, desc=f"country reforecast ({product_type})"):
+        download_glofas_reforecast_country_year(
+            year=year,
+            product_type=product_type,
+            max_leadtime_days=max_leadtime_days,
+            max_leadtime_chunk=max_leadtime_chunk,
+            rainy_season_only=rainy_season_only,
+            clobber=clobber,
+            max_workers=max_workers,
+        )
+
+
+def load_glofas_reforecast_country_pixel(
+    lon: float,
+    lat: float,
+    product_type: Literal["ensemble", "control"] = "ensemble",
+    years: range = range(2003, 2025),
+    max_leadtime_days: int = 16,
+    max_leadtime_chunk: int = 4,
+    rainy_season_only: bool = True,
+) -> pd.DataFrame:
+    """Extract reforecast time series for a pixel from country-wide GRIBs.
+
+    Snaps (lon, lat) to the nearest GloFAS 0.05° grid point and reads that one
+    pixel out of each country-wide GRIB file already downloaded to blob.
+    Downloads files to temp/ on demand if not already cached locally.
+
+    Returns a dataframe with columns: time, valid_time, leadtime, dis24
+    (plus 'number' for ensemble product type).
+    """
+    glofas_lon, glofas_lat = get_glofas_grid_coords(lon, lat)
+    leadtimes = [x * 24 for x in range(1, max_leadtime_days + 1)]
+    leadtime_chunks = [
+        leadtimes[i : i + max_leadtime_chunk]
+        for i in range(0, len(leadtimes), max_leadtime_chunk)
+    ]
+    dfs = []
+    for year in tqdm(years, desc="years"):
+        for lt_chunk in leadtime_chunks:
+            lt_start, lt_end = lt_chunk[0], lt_chunk[-1]
+            blob_name = get_blob_name_country(
+                year, product_type, lt_start, lt_end
+            )
+            local_path = Path("temp") / Path(blob_name)
+            if not local_path.exists():
+                blob_data = blob.load_blob_data(blob_name)
+                local_path.parent.mkdir(parents=True, exist_ok=True)
+                local_path.write_bytes(blob_data)
+            try:
+                ds = xr.open_dataset(
+                    local_path,
+                    engine="cfgrib",
+                    backend_kwargs={"indexpath": ""},
+                )
+            except Exception as e:
+                print(f"Warning: skipping {blob_name}: {e}")
+                continue
+            da = ds["dis24"].sel(
+                latitude=glofas_lat, longitude=glofas_lon, method="nearest"
+            )
+            df_in = da.to_dataframe().reset_index()
+            keep = [
+                c
+                for c in ["number", "time", "step", "valid_time", "dis24"]
+                if c in df_in.columns
+            ]
+            df_in = df_in[keep]
+            df_in["leadtime"] = df_in["step"].dt.days
+            df_in = df_in.drop(columns=["step"])
+            dfs.append(df_in)
+    df = pd.concat(dfs, ignore_index=True)
+    sort_cols = [c for c in ["time", "leadtime", "number"] if c in df.columns]
+    return df.sort_values(sort_cols).reset_index(drop=True)
 
 
 def load_glofas_reforecast(

--- a/src/datasources/glofas.py
+++ b/src/datasources/glofas.py
@@ -1,5 +1,6 @@
 import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
 
@@ -579,6 +580,26 @@ def process_glofas_reforecast(
     stratus.upload_parquet_to_blob(df, out_blob)
 
 
+PROGRESS_BLOB = (
+    f"{src.constants.PROJECT_PREFIX}/processed/glofas/"
+    "reforecast_country_progress.parquet"
+)
+
+
+def _load_progress(prod_dev: Literal["prod", "dev"] = "dev") -> pd.DataFrame:
+    if blob.check_blob_exists(PROGRESS_BLOB, prod_dev=prod_dev):
+        return blob.load_parquet_from_blob(PROGRESS_BLOB, prod_dev=prod_dev)
+    return pd.DataFrame(
+        columns=["product_type", "year", "lt_start", "lt_end", "downloaded_at"]
+    )
+
+
+def _save_progress(
+    progress: pd.DataFrame, prod_dev: Literal["prod", "dev"] = "dev"
+) -> None:
+    blob.upload_parquet_to_blob(PROGRESS_BLOB, progress, prod_dev=prod_dev)
+
+
 def get_blob_name_country(
     year: int,
     product_type: Literal["ensemble", "control"],
@@ -692,24 +713,65 @@ def download_glofas_reforecast_country(
     clobber: bool = False,
     max_workers: int = 4,
     cds_url: str = None,
+    prod_dev: Literal["prod", "dev"] = "dev",
 ) -> None:
-    """Download whole-Nigeria GloFAS reforecast for multiple years.
+    """Download whole-Nigeria GloFAS reforecast, iterating leadtime chunks first.
 
-    Processes years in order (lowest first) so the blob store fills up
-    progressively and partial runs can resume without re-downloading.
-    Within each year, up to max_workers leadtime chunks run concurrently.
+    Iterates leadtime chunks in the outer loop and years in the inner loop so
+    the full historical record for short leadtimes is available before longer
+    ones begin. Up to max_workers years run concurrently per chunk. After each
+    successful download the progress parquet is updated in blob so a crash
+    mid-run doesn't lose track of completed files.
     """
-    for year in tqdm(years, desc=f"country reforecast ({product_type})"):
-        download_glofas_reforecast_country_year(
-            year=year,
-            product_type=product_type,
-            max_leadtime_days=max_leadtime_days,
-            max_leadtime_chunk=max_leadtime_chunk,
-            rainy_season_only=rainy_season_only,
-            clobber=clobber,
-            max_workers=max_workers,
-            cds_url=cds_url,
-        )
+    months = RAINY_SEASON_MONTHS_NUM if rainy_season_only else ALL_MONTHS_NUM
+    leadtimes = [x * 24 for x in range(1, max_leadtime_days + 1)]
+    leadtime_chunks = [
+        leadtimes[i : i + max_leadtime_chunk]
+        for i in range(0, len(leadtimes), max_leadtime_chunk)
+    ]
+
+    progress = _load_progress(prod_dev)
+
+    for lt_chunk in tqdm(leadtime_chunks, desc=f"lt chunks ({product_type})"):
+        lt_start, lt_end = lt_chunk[0], lt_chunk[-1]
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = {
+                executor.submit(
+                    _download_country_chunk,
+                    year,
+                    lt_chunk,
+                    product_type,
+                    months,
+                    clobber,
+                    cds_url,
+                ): year
+                for year in years
+            }
+            for future in tqdm(
+                as_completed(futures),
+                total=len(futures),
+                desc=f"lt{lt_start}-{lt_end}",
+            ):
+                year = futures[future]
+                try:
+                    future.result()
+                    row = pd.DataFrame(
+                        [
+                            {
+                                "product_type": product_type,
+                                "year": year,
+                                "lt_start": lt_start,
+                                "lt_end": lt_end,
+                                "downloaded_at": datetime.now(
+                                    timezone.utc
+                                ).isoformat(),
+                            }
+                        ]
+                    )
+                    progress = pd.concat([progress, row], ignore_index=True)
+                    _save_progress(progress, prod_dev)
+                except Exception as e:
+                    print(f"Failed year={year} lt={lt_start}-{lt_end}: {e}")
 
 
 def load_glofas_reforecast_country_pixel(

--- a/src/datasources/glofas.py
+++ b/src/datasources/glofas.py
@@ -755,21 +755,28 @@ def download_glofas_reforecast_country(
                 year = futures[future]
                 try:
                     future.result()
-                    row = pd.DataFrame(
-                        [
-                            {
-                                "product_type": product_type,
-                                "year": year,
-                                "lt_start": lt_start,
-                                "lt_end": lt_end,
-                                "downloaded_at": datetime.now(
-                                    timezone.utc
-                                ).isoformat(),
-                            }
-                        ]
-                    )
-                    progress = pd.concat([progress, row], ignore_index=True)
-                    _save_progress(progress, prod_dev)
+                    already = (
+                        (progress["product_type"] == product_type)
+                        & (progress["year"] == year)
+                        & (progress["lt_start"] == lt_start)
+                        & (progress["lt_end"] == lt_end)
+                    ).any()
+                    if not already:
+                        row = pd.DataFrame(
+                            [
+                                {
+                                    "product_type": product_type,
+                                    "year": year,
+                                    "lt_start": lt_start,
+                                    "lt_end": lt_end,
+                                    "downloaded_at": datetime.now(
+                                        timezone.utc
+                                    ).isoformat(),
+                                }
+                            ]
+                        )
+                        progress = pd.concat([progress, row], ignore_index=True)
+                        _save_progress(progress, prod_dev)
                 except Exception as e:
                     print(f"Failed year={year} lt={lt_start}-{lt_end}: {e}")
 

--- a/src/utils/cds_utils.py
+++ b/src/utils/cds_utils.py
@@ -6,6 +6,19 @@ import cdsapi
 import ocha_stratus as stratus
 
 
+def _make_cds_client() -> cdsapi.Client:
+    """Instantiate a CDS API client.
+
+    On Databricks, CDSAPI_URL and CDSAPI_KEY are injected as env vars by the
+    cluster policy. Locally, falls back to ~/.cdsapirc.
+    """
+    url = os.getenv("CDSAPI_URL")
+    key = os.getenv("CDSAPI_KEY")
+    if url and key:
+        return cdsapi.Client(url=url, key=key)
+    return cdsapi.Client()
+
+
 def download_raw_cds_api_to_blob(
     dataset: str,
     request: dict,
@@ -16,7 +29,7 @@ def download_raw_cds_api_to_blob(
     local_filepath = "temp" / Path(blob_name)
     if not local_filepath.parent.exists():
         os.makedirs(local_filepath.parent)
-    c = cdsapi.Client()
+    c = _make_cds_client()
     response = c.retrieve(dataset, request)
     response.download(local_filepath)
     with open(local_filepath, "rb") as file:

--- a/src/utils/cds_utils.py
+++ b/src/utils/cds_utils.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 from pathlib import Path
 from typing import Literal
 
@@ -29,9 +30,11 @@ def download_raw_cds_api_to_blob(
     keep_local_copy: bool = True,
     cds_url: str = None,
 ):
-    local_filepath = "temp" / Path(blob_name)
-    if not local_filepath.parent.exists():
-        os.makedirs(local_filepath.parent)
+    # Use /tmp on Databricks (repo checkout dir is read-only);
+    # respect CDS_TEMP_DIR env var or fall back to "temp" locally.
+    base = Path(os.getenv("CDS_TEMP_DIR", tempfile.gettempdir()))
+    local_filepath = base / Path(blob_name)
+    local_filepath.parent.mkdir(parents=True, exist_ok=True)
     c = _make_cds_client(url=cds_url)
     response = c.retrieve(dataset, request)
     response.download(local_filepath)

--- a/src/utils/cds_utils.py
+++ b/src/utils/cds_utils.py
@@ -6,16 +6,18 @@ import cdsapi
 import ocha_stratus as stratus
 
 
-def _make_cds_client() -> cdsapi.Client:
+def _make_cds_client(url: str = None) -> cdsapi.Client:
     """Instantiate a CDS API client.
 
     On Databricks, CDSAPI_URL and CDSAPI_KEY are injected as env vars by the
-    cluster policy. Locally, falls back to ~/.cdsapirc.
+    cluster policy. Locally, falls back to ~/.cdsapirc. Pass url to override
+    the env var (e.g. when the policy enforces an endpoint that doesn't serve
+    a particular dataset).
     """
-    url = os.getenv("CDSAPI_URL")
+    resolved_url = url or os.getenv("CDSAPI_URL")
     key = os.getenv("CDSAPI_KEY")
-    if url and key:
-        return cdsapi.Client(url=url, key=key)
+    if resolved_url and key:
+        return cdsapi.Client(url=resolved_url, key=key)
     return cdsapi.Client()
 
 
@@ -25,11 +27,12 @@ def download_raw_cds_api_to_blob(
     blob_name: str,
     prod_dev: Literal["prod", "dev"] = "dev",
     keep_local_copy: bool = True,
+    cds_url: str = None,
 ):
     local_filepath = "temp" / Path(blob_name)
     if not local_filepath.parent.exists():
         os.makedirs(local_filepath.parent)
-    c = _make_cds_client()
+    c = _make_cds_client(url=cds_url)
     response = c.retrieve(dataset, request)
     response.download(local_filepath)
     with open(local_filepath, "rb") as file:


### PR DESCRIPTION
## Summary

- Adds functions to download the full-Nigeria GloFAS reforecast (~200×240 pixel bbox) rather than individual station points, so any pixel in the country can be analysed
- Adds `load_glofas_reforecast_country_pixel(lon, lat)` for single-pixel extraction from the downloaded GRIBs
- Wires up a Databricks Asset Bundle job (`databricks.yml`) for the long-running download

## Differences from the existing single-station job ([909961299936682](https://adb-6009046713167663.3.azuredatabricks.net/jobs/909961299936682?o=6009046713167663))

| | Single-station job (909961299936682) | This job (619598372576627) |
|---|---|---|
| **Scope** | One pixel (Wuroboki coordinates) | Full Nigeria bbox (~200×240 px at 0.05°) |
| **Blob path** | `reforecast/wuroboki_reforecast_ens_{year}_lt{chunk}.grib` | `reforecast_country/glofas_raw_reforecast_country_{product_type}_{year}_lt{lt_start}-{lt_end}.grib` |
| **Outer loop** | Years | Leadtime chunks — so short-LT historical record completes first |
| **Inner concurrency** | Leadtime chunks (4 workers) | Years (4 workers) |
| **Progress tracking** | None | Parquet written to blob after every successful file |
| **CDS URL** | Hardcoded `ewds.climate.copernicus.eu` in notebook | Passed via `cds_url` job parameter — needed because the Job Compute policy injects the wrong URL (`cds.climate.copernicus.eu`) as an env var |
| **Temp dir** | Default (notebook working dir) | Explicitly `/tmp` — repo checkout is read-only on Job Compute clusters |
| **Entrypoint** | Notebook | Python script (`pipelines/download_glofas_reforecast_country.py`) via DAB |

CDS request format was matched to the working station job: numeric months, singular `"ensemble_perturbed_reforecast"` product type, `max_workers=4`.

## Full download running

**Run**: https://adb-6009046713167663.3.azuredatabricks.net/?o=6009046713167663#job/619598372576627/run/479474023022760
**Job**: [dev adm_tdowning] Download GloFAS Reforecast (Country) — job 619598372576627
**Started**: 2026-06-25 ~17:55 UTC
**Scope**: ensemble, 2003–2024, rainy season (Jun–Dec), 16-day leadtime

**ETA**: 2026-06-26 05:00–16:00 UTC (optimistic–conservative, depending on CDS queue)

**Estimated output**:
- 88 files × ~344 MB = ~30 GB ensemble
- Control run (separate job kick-off after this completes): ~2.8 GB
- ~33 GB total (empirical from smoke test; GRIB2 compression beats the naive estimate)

Note from CDS: dataset under a "temporary freeze" for updates past GloFAS v4.2. Historical years 2003–2024 download fine.

## Test plan

- [x] Smoke test passed: `ensemble, 2003, lt24-96, rainy season` → 344 MB blob in `raw/glofas/reforecast_country/`
- [x] Full ensemble run kicked off (see above)
- [ ] Verify blobs after run completes
- [ ] Kick off control run after merge: `databricks bundle run download_glofas_reforecast_country -t dev -p DEFAULT --python-named-params "product_type=control"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)